### PR TITLE
Add extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
 	},
 	"extra": {
 		"typo3/cms": {
+			"extension-key": "calendarize_news",
 			"cms-package-dir": "{$vendor-dir}/typo3/cms",
 			"web-dir": ".Build/Web",
 			"Package": {


### PR DESCRIPTION
Specifying the extension key in the extra section of the composer.json
is now mandatory for TYPO3 extensions.