### PR TITLE
Add phpstan checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,14 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Install the right version
-        run: composer require "typo3/cms-core:^${{ matrix.typo3 }}" "typo3/cms-workspaces:^${{ matrix.typo3 }}" -W
+      - name: Install the right version(s)
+        run: composer require "typo3/cms-core:^${{ matrix.typo3 }}" "typo3/cms-extbase:^${{ matrix.typo3 }}" "typo3/cms-workspaces:^${{ matrix.typo3 }}" -W
 
       - name: Run PHP CS Fixer checks
         run: composer run tool:php-cs-fixer-check
+
+      - name: Run phpstan checks
+        run: composer run tool:phpstan
 
       #- name: Unit Tests with phpunit
       #  run: composer run tool:phpunit --

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install the right version(s)
         run: composer require "typo3/cms-core:^${{ matrix.typo3 }}" "typo3/cms-extbase:^${{ matrix.typo3 }}" "typo3/cms-workspaces:^${{ matrix.typo3 }}" -W
 
+      - name: composer validate
+        run: composer validate
+
       - name: Run PHP CS Fixer checks
         run: composer run tool:php-cs-fixer-check
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Build/*
 .php-cs-fixer.cache
 composer.lock
+/var

--- a/Classes/Persistence/IndexQuery.php
+++ b/Classes/Persistence/IndexQuery.php
@@ -17,7 +17,7 @@ class IndexQuery extends Query
     /**
      * Executes the query against the database and returns the result.
      *
-     * @param $returnRawQueryResult boolean avoids the object mapping by the persistence
+     * @param bool $returnRawQueryResult avoids the object mapping by the persistence
      *
      * @return \TYPO3\CMS\Extbase\Persistence\QueryResultInterface|array The query result object or an array if $returnRawQueryResult is TRUE
      *

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
 	"require": {
 		"php": "^7.3||^7.4",
 		"typo3/cms-core": "^10.4",
+		"typo3/cms-extbase": "^10.4",
 		"lochmueller/calendarize": "^10.0||^11.0",
 		"lochmueller/autoloader": "^7.0",
 		"georgringer/news": "^8.5"
@@ -52,7 +53,8 @@
 		"squizlabs/php_codesniffer": "^2.6",
 		"phpmd/phpmd": "^2.4",
 		"friendsofphp/php-cs-fixer": "^3.0",
-		"phpunit/phpunit": "^9.5"
+		"phpunit/phpunit": "^9.5",
+		"phpstan/phpstan": "^0.12.82"
 	},
 	"config": {
 		"vendor-dir": ".Build/vendor",
@@ -71,7 +73,7 @@
 	"scripts": {
 		"code": [
 			"@tool:php-cs-fixer",
-			"@tool:phpunit"
+			"@tool:phpstan"
 		],
 		"tool:php-cs-fixer": [
 			"php-cs-fixer fix --config Resources/Private/Build/PhpCsFixer.php"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,30 @@
+includes:
+	# may be required later for unit tests with prophecy
+	#- ../.Build/vendor/jangregor/phpstan-prophecy/extension.neon
+
+parameters:
+	tmpDir: %currentWorkingDirectory%/var/cache/phpstan
+
+	parallel:
+		# Don't be overly greedy on machines with more CPU's to be a good neighbor especially on CI
+		maximumNumberOfProcesses: 5
+
+	level: 5
+
+	paths:
+		- %currentWorkingDirectory%/Classes
+		# todo: check unit tests as well
+		#- %currentWorkingDirectory%/Tests
+
+	# scan, do not check
+	scanDirectories:
+		- %currentWorkingDirectory%/.Build/Web/typo3/sysext
+		- %currentWorkingDirectory%/.Build/Web/typo3conf/ext
+
+	# for link to perform check and jump to file in PhpStorm, also install e.g. plugin "Awesome Console"
+	editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
+
+	ignoreErrors:
+		# https://phpstan.org/user-guide/ignoring-errors
+		# use regex here
+		# ...


### PR DESCRIPTION
- add phpstan
- add composer validate 

phpstan up to level 5. After that it gets interesting but for that we might have to add declarations for arrays in phpdoc and wasn't sure how, but difficult to ascertain for me what might be in the arrays. But as fallback one could use `@param array <multiple>` or ignore it via phpstan config, but wasn't sure. 

Also, more typehints might be useful but that might break things if extensions are using classes and overriding things - not sure how best to do that right now either.

This is just the first step and can be extended :smile: