### PR TITLE
[TASK] Run CI test regulary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Testing calendarize_news
-on: [push, pull_request]
+on:
+  push
+  pull_request
+  schedule:
+    - cron: '10 3 * * *'
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Not in commit:

- based this on TYPO3 styleguide extension, see https://github.com/TYPO3/styleguide/blob/main/.github/workflows/tests.yml
- currently the latest pull requests (PR) fail but it looks like it is not something in the PR. The tests do not run regularly, and this means possible errors due to conflicts in this extension and required extensions are not caught early. Last time tests were run is 6 months ago see acttions: https://github.com/lochmueller/calendarize_news/actions