### PR TITLE
[TASK] Add composer allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,11 @@
 	},
 	"config": {
 		"vendor-dir": ".Build/vendor",
-		"bin-dir": ".Build/bin"
+		"bin-dir": ".Build/bin",
+		"allow-plugins": {
+			"typo3/class-alias-loader": true,
+			"typo3/cms-composer-installers": true
+		}
 	},
 	"extra": {
 		"typo3/cms": {


### PR DESCRIPTION
For latest Composer versions, Composer asks if we trust certain
plugins on some actions. This is for
example the case when requiring addition packages for the test
runs.

Adding the allowed plugins is customary in TYPO3 packages,
for example typo3/cms-styleguide and typo3/cms (TYPO3 core monorepo).

Not adding the allow-plugins will result in Composer asking
additional questions, e.g.

composer require typo3/cms-core:^10.4 typo3/cms-extbase:^10.4 typo3/cms-workspaces:^10.4 georgringer/news:^9 -W
typo3/class-alias-loader contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "typo3/class-alias-loader" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y

The following is added to composer.json:

"allow-plugins": {
  "typo3/class-alias-loader": true,
  "typo3/cms-composer-installers": true
}