### PR TITLE
[TASK] Restrict scheduled CI run to main repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     - cron: '10 3 * * *'
 jobs:
   build:
+    # only run jobs via scheduled workflow in main repo, not in forks
+    if: (github.event_name == 'schedule' && github.repository == 'lochmueller/calendarize_news') || (github.event_name != 'schedule')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In the GitHub CI file, a scheduled run is configured, so that the checks and tests run once a day. This is a good idea, to change possible problems due to updated depencies early.

However, the scheduled run also runs in the forks and this is unnecessary. The checks will run in all forks of contributors (in case they have enabled this in general) and they will get notifcations in case of failures. This is unnecessary, it is enough for the scheduled runs to run in one repo.

-----

_Additional information (not in commit):_ [I initially added the scheduled runs here in calendarize_news](https://github.com/lochmueller/calendarize_news/blame/master/.github/workflows/ci.yml). I used the configuration from sypets/brofix (which benefited from some changes by core developers), but in the case of the scheduled runs, I now noticed that this also runs in the forks and I think it can be a bit annoying. See also 

* my PR in styleguide: `https://github.com/TYPO3/styleguide/pull/389` (this will probably be rejected)
* discussion on GitHub: https://github.com/orgs/community/discussions/26684
* feature request on GitHub: https://github.com/orgs/community/discussions/16109

In the end, it is up to the extension maintainer (Tim), so feel to close or merge.
