### PR TITLE
Raise requirement testing framework

### DIFF
--- a/Tests/Functional/NewsIndexTest.php
+++ b/Tests/Functional/NewsIndexTest.php
@@ -37,7 +37,7 @@ class NewsIndexTest extends FunctionalTestCase
         $rows = $queryBuilder
             ->select('*')
             ->from('tx_calendarize_domain_model_index')
-            ->execute()->fetchAllAssociative();
+            ->executeQuery()->fetchAllAssociative();
 
         self::assertCount(1, $rows);
         self::assertEquals(20, $rows[0]['foreign_uid']);

--- a/Tests/Functional/NewsIndexTest.php
+++ b/Tests/Functional/NewsIndexTest.php
@@ -12,16 +12,16 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class NewsIndexTest extends FunctionalTestCase
 {
-    public function __construct()
-    {
-        // Initialize inside constructor to support TYPO3 v10
-        $this->coreExtensionsToLoad = ['extbase', 'fluid'];
-        $this->testExtensionsToLoad = ['typo3conf/ext/news', 'typo3conf/ext/calendarize', 'typo3conf/ext/calendarize_news'];
-        if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() < 12) {
-            array_splice($this->testExtensionsToLoad, 1, 0, 'typo3conf/ext/autoloader');
-        }
-        parent::__construct();
-    }
+    protected array $coreExtensionsToLoad = [
+        'extbase',
+        'fluid',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/news',
+        'typo3conf/ext/calendarize',
+        'typo3conf/ext/calendarize_news',
+    ];
 
     public function testNewsIndexing(): void
     {

--- a/Tests/Functional/Xclass/NewsLinkViewHelperTest.php
+++ b/Tests/Functional/Xclass/NewsLinkViewHelperTest.php
@@ -9,13 +9,16 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class NewsLinkViewHelperTest extends FunctionalTestCase
 {
-    public function __construct()
-    {
-        // Initialize inside constructor to support TYPO3 v10
-        $this->coreExtensionsToLoad = ['extbase', 'fluid'];
-        $this->testExtensionsToLoad = ['typo3conf/ext/news', 'typo3conf/ext/calendarize_news'];
-        parent::__construct();
-    }
+    protected array $coreExtensionsToLoad = [
+        'extbase',
+        'fluid',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/news',
+        'typo3conf/ext/calendarize',
+        'typo3conf/ext/calendarize_news',
+    ];
 
     public function testViewHelperRender(): void
     {

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
 		"friendsofphp/php-cs-fixer": "^3.0",
 		"phpunit/phpunit": "^9.5||^10.1",
 		"phpstan/phpstan": "^0.12.82",
-		"typo3/testing-framework": "^6.0.0||^7.0.4||^8.3.1"
+		"typo3/testing-framework": "^8.3.1"
 	},
 	"config": {
 		"vendor-dir": ".Build/vendor",


### PR DESCRIPTION
- require at least typo3/testing-framework ^8
- fix errors related to functional tests
  - Do not use constructor without argument : conflict with `PHPUnit\Framework\TestCase::_construct(string $name)`
  - using `QueryBuilder::execute() `is deprecated in v12, see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-96972-DeprecateQueryBuilderexecute.html