### PR TITLE
!!![TASK] Drop v12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: "8.1"
-            typo3: "12.4"
-            news: "12.0"
-          - php: "8.2"
-            typo3: "12.4"
-            news: "12.0"
           - php: "8.2"
             typo3: "13.4"
             news: "12.0"

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
 		}
 	],
 	"require": {
-		"php": "^8.1",
-		"typo3/cms-core": "^12.4||^13.4",
+		"php": "^8.2",
+		"typo3/cms-core": "^13.4",
 		"lochmueller/calendarize": "^13.0||^14.0",
 		"georgringer/news": "^12.0"
 	},

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,8 +17,8 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'tim@fruit-lab.de',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.4.99',
-            'php' => '8.1.0-8.4.99',
+            'typo3' => '13.4.0-13.4.99',
+            'php' => '8.2.0-8.5.99',
             'calendarize' => '13.0.0-14.99.99',
             'news' => '12.0.0-12.99.99',
         ],


### PR DESCRIPTION
* TYPO3 v13 has PHP requiremens: PHP >= 8.2.0 <= 8.5.99, see https://get.typo3.org/version/13