### PR TITLE
[TASK] Fix CI

### DIFF
--- a/Classes/EventListener/ModifyFlexformEvent.php
+++ b/Classes/EventListener/ModifyFlexformEvent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace HDNET\CalendarizeNews\EventListener;
 
 use TYPO3\CMS\Core\Configuration\Event\AfterFlexFormDataStructureParsedEvent;

--- a/Classes/Persistence/IndexResult.php
+++ b/Classes/Persistence/IndexResult.php
@@ -35,7 +35,7 @@ class IndexResult extends QueryResult
     /**
      * Loads the objects this QueryResult is supposed to hold.
      */
-    protected function initializeIndex()
+    protected function initializeIndex(): void
     {
         if (!\is_array($this->indexResult)) {
             $newsIds = [];
@@ -66,7 +66,7 @@ class IndexResult extends QueryResult
     /**
      * Loads the objects this QueryResult is supposed to hold.
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         if (!\is_array($this->queryResult)) {
             $this->initializeIndex();

--- a/Classes/Persistence/IndexResult.php
+++ b/Classes/Persistence/IndexResult.php
@@ -54,11 +54,11 @@ class IndexResult extends QueryResult
                 'startTime' => QueryInterface::ORDER_ASCENDING,
             ]);
             $this->indexResult = $query->matching(
-                $query->logicalAnd([
+                $query->logicalAnd(
                     $query->equals('foreignTable', 'tx_news_domain_model_news'),
                     $query->in('foreignUid', $newsIds),
                     $query->greaterThanOrEqual('startDate', DateTimeUtility::getNow()->format('Y-m-d')),
-                ])
+                )
             )->execute()->toArray();
         }
     }

--- a/Classes/Service/NewsOverwrite.php
+++ b/Classes/Service/NewsOverwrite.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 
 class NewsOverwrite implements SingletonInterface
 {
-    public function overWriteNewsPropertiesByIndex(News $news, Index $index)
+    public function overWriteNewsPropertiesByIndex(News $news, Index $index): void
     {
         ObjectAccess::setProperty(
             $news,

--- a/Classes/Xclass/NewsController.php
+++ b/Classes/Xclass/NewsController.php
@@ -15,7 +15,7 @@ class NewsController extends \GeorgRinger\News\Controller\NewsController
      */
     protected $index;
 
-    public function initializeDetailAction()
+    public function initializeDetailAction(): void
     {
         if ($this->request->hasArgument('index')) {
             $index = $this->request->getArgument('index');

--- a/Resources/Private/Build/PhpCsFixer.php
+++ b/Resources/Private/Build/PhpCsFixer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 $baseDir = dirname(__DIR__, 3);
 
 require $baseDir . '/.Build/vendor/autoload.php';

--- a/Tests/Unit/Service/NewsOverwriteTest.php
+++ b/Tests/Unit/Service/NewsOverwriteTest.php
@@ -16,7 +16,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 class NewsOverwriteTest extends UnitTestCase
 {
-    public function testOverWriteNewsPropertiesByIndexObject()
+    public function testOverWriteNewsPropertiesByIndexObject(): void
     {
         $service = new NewsOverwrite();
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.0",
 		"namelesscoder/typo3-repository-client": "1.2.0",
-		"phpstan/phpstan": "^0.12.82",
+		"phpstan/phpstan": "^1.8",
 		"squizlabs/php_codesniffer": "^2.6",
 		"typo3/testing-framework": "^8.3"
 	},
@@ -95,7 +95,7 @@
 			"docker run --rm -v $(pwd):/data phpdoc/phpdoc -d Classes -t .Build/phpdoc"
 		],
 		"tool:phpstan": [
-			"phpstan analyse Classes --memory-limit 1G --level 5"
+			"phpstan analyse --memory-limit 1G --level 5 Classes"
 		],
 		"tool:phpunit": [
 			"phpunit --configuration=Tests/Unit/UnitTests.xml"


### PR DESCRIPTION
* run php-cs-fixer
* raise requirement for phpstan/phpstan to ^1.8
* fix parameter to logicalAnd, should either use an array and unpack with ...$array or pass individual arguments, otherwise phpstan complains with:

 ```
------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Persistence/IndexResult.php                                                                                                                                                                                                                
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  57     Parameter #1 ...$constraints of method TYPO3\CMS\Extbase\Persistence\QueryInterface<TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface>::logicalAnd() expects TYPO3\CMS\Extbase\Persistence\Generic\Qom\ConstraintInterface, array<int,  
         TYPO3\CMS\Extbase\Persistence\Generic\Qom\ComparisonInterface> given.                                                                                                                                                                      
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 


```